### PR TITLE
ci: add conventional commits check

### DIFF
--- a/.github/workflows/pr-verification.yaml
+++ b/.github/workflows/pr-verification.yaml
@@ -16,6 +16,11 @@ concurrency:
 permissions: {}
 
 jobs:
+  quality-checks:
+    permissions:
+      pull-requests: write
+    uses: ./.github/workflows/quality-checks.yaml
+
   build:
     uses: ./.github/workflows/build.yaml
     secrets: inherit

--- a/.github/workflows/quality-checks.yaml
+++ b/.github/workflows/quality-checks.yaml
@@ -1,0 +1,17 @@
+# Copyright (C) 2023 TomTom NV. All rights reserved.
+
+---
+
+name: Quality checks
+
+on:
+  workflow_call:
+
+jobs:
+  commisery:
+    name: Conventional Commits compliance
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tomtom-international/commisery-action@v2
+        with:
+          token: ${{ github.token }}


### PR DESCRIPTION
Adds commisery check for validating that commits follow the conventional commits guidelines. 