### PR TITLE
fix: app is crashing when replanning and then viewing route overview

### DIFF
--- a/TomTomSDKExamples/Examples/UseCase/OnlineNavigationContent.swift
+++ b/TomTomSDKExamples/Examples/UseCase/OnlineNavigationContent.swift
@@ -121,10 +121,8 @@ extension NavigationController: NavigationRouteObserver {
     func didProposeRoutePlan(routePlan _: TomTomSDKNavigationEngines.RoutePlan, reason _: TomTomSDKNavigationEngines.RouteReplanningReason) {}
 
     func didReplanRoute(replannedRoute: TomTomSDKRoute.Route, reason: TomTomSDKNavigationEngines.RouteReplanningReason) {
-        if reason != RouteReplanningReason.refresh &&
-            reason != RouteReplanningReason.increment &&
-            reason != RouteReplanningReason.languageChange
-        {
+        let nonTriggeringReasons: [RouteReplanningReason] = [.refresh, .increment, .languageChange]
+        if nonTriggeringReasons.contains(reason) == false {
             displayedRouteSubject.send(nil)
             displayedRouteSubject.send(replannedRoute)
         }

--- a/TomTomSDKExamples/Examples/UseCase/OnlineNavigationContent.swift
+++ b/TomTomSDKExamples/Examples/UseCase/OnlineNavigationContent.swift
@@ -120,8 +120,14 @@ extension NavigationController: NavigationRouteObserver {
 
     func didProposeRoutePlan(routePlan _: TomTomSDKNavigationEngines.RoutePlan, reason _: TomTomSDKNavigationEngines.RouteReplanningReason) {}
 
-    func didReplanRoute(replannedRoute: TomTomSDKRoute.Route, reason _: TomTomSDKNavigationEngines.RouteReplanningReason) {
-        displayedRouteSubject.send(replannedRoute)
+    func didReplanRoute(replannedRoute: TomTomSDKRoute.Route, reason: TomTomSDKNavigationEngines.RouteReplanningReason) {
+        if reason != RouteReplanningReason.refresh &&
+            reason != RouteReplanningReason.increment &&
+            reason != RouteReplanningReason.languageChange
+        {
+            displayedRouteSubject.send(nil)
+            displayedRouteSubject.send(replannedRoute)
+        }
     }
 
     func didChangeRoutes(navigatedRoutes _: TomTomSDKNavigation.NavigatedRoutes) {}
@@ -504,12 +510,12 @@ extension MapCoordinator {
     func observe(navigationController: NavigationController) {
         navigationController.displayedRouteSubject.sink { [weak self] route in
             guard let self = self else { return }
-            self.map?.removeRoutes()
             if let route = route {
                 self.addRouteToMap(route: route)
                 self.setCamera(trackingMode: .followRoute)
             } else {
                 self.routeOnMap = nil
+                self.map?.removeRoutes()
                 self.setCamera(trackingMode: .follow)
             }
         }.store(in: &cancellableBag)


### PR DESCRIPTION
What
---
App is crashing when replanning and then viewing route overview.

Steps to reproduce:

1. Long press location A, route will show
2. Then long press location B, route A will hide, second route will show
3. Change camera tracking to`routeOverview`
4. App will crash

How
---
Align with the
- [Build a navigation app](https://developer.tomtom.com/ios/navigation/documentation/use-cases/build-a-navigation-app) tutorial
- Deviation handling in [Android Examples](https://github.com/tomtom-international/tomtom-navigation-android-examples/blob/d6410761c28daeafab2ab83222c9dd891e58a759/app/src/main/java/com/tomtom/sdk/examples/usecase/BasicNavigationActivity.kt#L376)