### PR TITLE
feat: use new online Navigation factory methods

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -19,7 +19,6 @@ target 'TomTomSDKExamples' do
   pod 'TomTomSDKMapDisplay', '0.22.1'
   pod 'TomTomSDKNavigation', '0.22.1'
   pod 'TomTomSDKNavigationEngines', '0.22.1'
-  pod 'TomTomSDKNavigationOffline', '0.22.1'
   pod 'TomTomSDKNavigationOnline', '0.22.1'
   pod 'TomTomSDKNavigationUI', '0.22.1'
   pod 'TomTomSDKRoute', '0.22.1'

--- a/Podfile
+++ b/Podfile
@@ -19,6 +19,8 @@ target 'TomTomSDKExamples' do
   pod 'TomTomSDKMapDisplay', '0.22.1'
   pod 'TomTomSDKNavigation', '0.22.1'
   pod 'TomTomSDKNavigationEngines', '0.22.1'
+  pod 'TomTomSDKNavigationOffline', '0.22.1'
+  pod 'TomTomSDKNavigationOnline', '0.22.1'
   pod 'TomTomSDKNavigationUI', '0.22.1'
   pod 'TomTomSDKRoute', '0.22.1'
   pod 'TomTomSDKRoutePlanner', '0.22.1'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -4,7 +4,9 @@ PODS:
   - TomTomSDKBindingFrameworkLoggingInternal (0.22.1)
   - TomTomSDKBindingFrameworkMemChannelInternal (0.22.1)
   - TomTomSDKBindingFrameworkSecurityInternal (0.22.1)
+  - TomTomSDKBindingLocationContextProviderInternal (0.22.1)
   - TomTomSDKBindingMapDisplayEngineInternal (0.22.1)
+  - TomTomSDKBindingMapMatchingInternal (0.22.1)
   - TomTomSDKBindingNavigationClientInternal (0.22.1):
     - TomTomSDKBindingFrameworkClientCommonInternal (= 0.22.1)
     - TomTomSDKBindingFrameworkMemChannelInternal (= 0.22.1)
@@ -18,15 +20,92 @@ PODS:
     - TomTomSDKBindingFrameworkLoggingInternal (= 0.22.1)
     - TomTomSDKBindingFrameworkSecurityInternal (= 0.22.1)
   - TomTomSDKBindingNavigationTextGenerationInternal (0.22.1)
+  - TomTomSDKBindingNavigationTileStoreAccessInternal (0.22.1):
+    - TomTomSDKBindingFrameworkLoggingInternal (= 0.22.1)
+  - TomTomSDKBindingNavigationTilingInternal (0.22.1)
+  - TomTomSDKBindingNDSSQLiteInternal (0.22.1)
+  - TomTomSDKBindingNDSStoreAccessInternal (0.22.1):
+    - TomTomSDKBindingNDSSQLiteInternal (= 0.22.1)
+  - TomTomSDKBindingOnboardMapUpdateInternal (0.22.1):
+    - TomTomSDKBindingNDSSQLiteInternal (= 0.22.1)
+    - TomTomSDKBindingNDSStoreAccessInternal (= 0.22.1)
+  - TomTomSDKBindingOnboardOpenLRInternal (0.22.1):
+    - TomTomSDKBindingFrameworkLoggingInternal (= 0.22.1)
+    - TomTomSDKBindingNDSSQLiteInternal (= 0.22.1)
+    - TomTomSDKBindingNDSStoreAccessInternal (= 0.22.1)
+  - TomTomSDKBindingRouteProjectionInternal (0.22.1)
+  - TomTomSDKBindingVehicleHorizonInternal (0.22.1)
+  - TomTomSDKBindingVehicleHorizonNDSMapInternal (0.22.1):
+    - TomTomSDKBindingNDSSQLiteInternal (= 0.22.1)
+    - TomTomSDKBindingNDSStoreAccessInternal (= 0.22.1)
   - TomTomSDKCommon (0.22.1):
     - TomTomSDKBindingFrameworkLoggingInternal (= 0.22.1)
   - TomTomSDKCommonUI (0.22.1):
     - TomTomSDKCommon (= 0.22.1)
+  - TomTomSDKDataManagement (0.22.1):
+    - TomTomSDKCommon (= 0.22.1)
+  - TomTomSDKDataManagementOffline (0.22.1):
+    - TomTomSDKBindingNavigationTilingInternal (= 0.22.1)
+    - TomTomSDKBindingNDSStoreAccessInternal (= 0.22.1)
+    - TomTomSDKBindingOnboardMapUpdateInternal (= 0.22.1)
+    - TomTomSDKCommon (= 0.22.1)
+    - TomTomSDKDataManagement (= 0.22.1)
+    - TomTomSDKNetworking (= 0.22.1)
+  - TomTomSDKDataStoreMaintenanceEngine (0.22.1):
+    - TomTomSDKDataManagement (= 0.22.1)
+    - TomTomSDKNavigation (= 0.22.1)
+    - TomTomSDKNavigationEngines (= 0.22.1)
   - TomTomSDKDefaultTextToSpeech (0.22.1):
     - TomTomSDKFeatureToggle (= 0.22.1)
     - TomTomSDKTextToSpeechEngine (= 0.22.1)
   - TomTomSDKFeatureToggle (0.22.1):
     - TomTomSDKCommon (= 0.22.1)
+  - TomTomSDKHazards (0.22.1):
+    - TomTomSDKCommon (= 0.22.1)
+    - TomTomSDKMQTT (= 0.22.1)
+  - TomTomSDKHazardsDataAdapterOnline (0.22.1):
+    - TomTomSDKCommon (= 0.22.1)
+    - TomTomSDKHazards (= 0.22.1)
+    - TomTomSDKNavigationHorizonDataAdapter (= 0.22.1)
+  - TomTomSDKHorizonEngineCommon (0.22.1):
+    - TomTomSDKBindingVehicleHorizonInternal (= 0.22.1)
+    - TomTomSDKCommon (= 0.22.1)
+    - TomTomSDKHazardsDataAdapterOnline (= 0.22.1)
+    - TomTomSDKLocationProvider (= 0.22.1)
+    - TomTomSDKNavigation (= 0.22.1)
+    - TomTomSDKNavigationEngines (= 0.22.1)
+    - TomTomSDKNavigationHorizonDataAdapter (= 0.22.1)
+    - TomTomSDKRoute (= 0.22.1)
+    - TomTomSDKSafetyLocationsDataAdapterOnline (= 0.22.1)
+  - TomTomSDKHorizonEngineOffline (0.22.1):
+    - TomTomSDKBindingOnboardOpenLRInternal (= 0.22.1)
+    - TomTomSDKBindingVehicleHorizonInternal (= 0.22.1)
+    - TomTomSDKBindingVehicleHorizonNDSMapInternal (= 0.22.1)
+    - TomTomSDKCommon (= 0.22.1)
+    - TomTomSDKDataManagement (= 0.22.1)
+    - TomTomSDKDataManagementOffline (= 0.22.1)
+    - TomTomSDKHorizonEngineCommon (= 0.22.1)
+    - TomTomSDKLocationProvider (= 0.22.1)
+    - TomTomSDKNavigation (= 0.22.1)
+    - TomTomSDKNavigationEngines (= 0.22.1)
+    - TomTomSDKNavigationHorizonDataAdapter (= 0.22.1)
+    - TomTomSDKRoute (= 0.22.1)
+  - TomTomSDKLocationContextProviderEngineOffline (0.22.1):
+    - TomTomSDKBindingLocationContextProviderInternal (= 0.22.1)
+    - TomTomSDKBindingNDSStoreAccessInternal (= 0.22.1)
+    - TomTomSDKCommon (= 0.22.1)
+    - TomTomSDKDataManagement (= 0.22.1)
+    - TomTomSDKDataManagementOffline (= 0.22.1)
+    - TomTomSDKLocationProvider (= 0.22.1)
+    - TomTomSDKNavigationEngines (= 0.22.1)
+    - TomTomSDKRoutePlanner (= 0.22.1)
+  - TomTomSDKLocationContextProviderEngineTileStore (0.22.1):
+    - TomTomSDKBindingLocationContextProviderInternal (= 0.22.1)
+    - TomTomSDKBindingNavigationTileStoreAccessInternal (= 0.22.1)
+    - TomTomSDKCommon (= 0.22.1)
+    - TomTomSDKLocationProvider (= 0.22.1)
+    - TomTomSDKNavigationEngines (= 0.22.1)
+    - TomTomSDKNavigationTileStore (= 0.22.1)
   - TomTomSDKLocationProvider (0.22.1):
     - TomTomSDKCommon (= 0.22.1)
   - TomTomSDKMapDisplay (0.22.1):
@@ -34,6 +113,35 @@ PODS:
     - TomTomSDKCommon (= 0.22.1)
     - TomTomSDKFeatureToggle (= 0.22.1)
     - TomTomSDKLocationProvider (= 0.22.1)
+  - TomTomSDKMapMatchingEngineCommon (0.22.1):
+    - TomTomSDKBindingMapMatchingInternal (= 0.22.1)
+    - TomTomSDKCommon (= 0.22.1)
+    - TomTomSDKDataManagement (= 0.22.1)
+    - TomTomSDKLocationProvider (= 0.22.1)
+    - TomTomSDKNavigationEngines (= 0.22.1)
+    - TomTomSDKRoute (= 0.22.1)
+  - TomTomSDKMapMatchingEngineOffline (0.22.1):
+    - TomTomSDKBindingMapMatchingInternal (= 0.22.1)
+    - TomTomSDKBindingNDSStoreAccessInternal (= 0.22.1)
+    - TomTomSDKCommon (= 0.22.1)
+    - TomTomSDKDataManagement (= 0.22.1)
+    - TomTomSDKDataManagementOffline (= 0.22.1)
+    - TomTomSDKLocationProvider (= 0.22.1)
+    - TomTomSDKMapMatchingEngineCommon (= 0.22.1)
+    - TomTomSDKNavigationEngines (= 0.22.1)
+    - TomTomSDKRoute (= 0.22.1)
+  - TomTomSDKMapMatchingEngineTileStore (0.22.1):
+    - TomTomSDKBindingMapMatchingInternal (= 0.22.1)
+    - TomTomSDKBindingNavigationTileStoreAccessInternal (= 0.22.1)
+    - TomTomSDKCommon (= 0.22.1)
+    - TomTomSDKDataManagement (= 0.22.1)
+    - TomTomSDKLocationProvider (= 0.22.1)
+    - TomTomSDKMapMatchingEngineCommon (= 0.22.1)
+    - TomTomSDKNavigationEngines (= 0.22.1)
+    - TomTomSDKNavigationTileStore (= 0.22.1)
+    - TomTomSDKRoute (= 0.22.1)
+  - TomTomSDKMQTT (0.22.1):
+    - TomTomSDKCommon (= 0.22.1)
   - TomTomSDKNavigation (0.22.1):
     - TomTomSDKBindingFrameworkClientCommonInternal (= 0.22.1)
     - TomTomSDKBindingFrameworkHTTPInternal (= 0.22.1)
@@ -59,6 +167,40 @@ PODS:
     - TomTomSDKRoute (= 0.22.1)
     - TomTomSDKRoutePlanner (= 0.22.1)
     - TomTomSDKRouteReplanner (= 0.22.1)
+  - TomTomSDKNavigationHorizonDataAdapter (0.22.1):
+    - TomTomSDKCommon (= 0.22.1)
+    - TomTomSDKNavigationEngines (= 0.22.1)
+  - TomTomSDKNavigationOffline (0.22.1):
+    - TomTomSDKDataManagementOffline (= 0.22.1)
+    - TomTomSDKDataStoreMaintenanceEngine (= 0.22.1)
+    - TomTomSDKHorizonEngineOffline (= 0.22.1)
+    - TomTomSDKLocationContextProviderEngineOffline (= 0.22.1)
+    - TomTomSDKLocationProvider (= 0.22.1)
+    - TomTomSDKMapMatchingEngineOffline (= 0.22.1)
+    - TomTomSDKNavigation (= 0.22.1)
+    - TomTomSDKNavigationEngines (= 0.22.1)
+    - TomTomSDKRouteProjectionEngineOffline (= 0.22.1)
+    - TomTomSDKRouteReplanner (= 0.22.1)
+    - TomTomSDKVehicle (= 0.22.1)
+  - TomTomSDKNavigationOnline (0.22.1):
+    - TomTomSDKDataStoreMaintenanceEngine (= 0.22.1)
+    - TomTomSDKLocationContextProviderEngineTileStore (= 0.22.1)
+    - TomTomSDKLocationProvider (= 0.22.1)
+    - TomTomSDKMapMatchingEngineTileStore (= 0.22.1)
+    - TomTomSDKNavigation (= 0.22.1)
+    - TomTomSDKNavigationEngines (= 0.22.1)
+    - TomTomSDKNavigationTileStore (= 0.22.1)
+    - TomTomSDKRouteProjectionEngineTileStore (= 0.22.1)
+    - TomTomSDKRouteReplanner (= 0.22.1)
+    - TomTomSDKVehicle (= 0.22.1)
+  - TomTomSDKNavigationTileStore (0.22.1):
+    - TomTomSDKBindingFrameworkSecurityInternal (= 0.22.1)
+    - TomTomSDKBindingNavigationTileStoreAccessInternal (= 0.22.1)
+    - TomTomSDKBindingNavigationTilingInternal (= 0.22.1)
+    - TomTomSDKCommon (= 0.22.1)
+    - TomTomSDKDataManagement (= 0.22.1)
+    - TomTomSDKFeatureToggle (= 0.22.1)
+    - TomTomSDKNetworking (= 0.22.1)
   - TomTomSDKNavigationUI (0.22.1):
     - TomTomSDKCommon (= 0.22.1)
     - TomTomSDKCommonUI (= 0.22.1)
@@ -85,6 +227,28 @@ PODS:
     - TomTomSDKLocationProvider (= 0.22.1)
     - TomTomSDKRoute (= 0.22.1)
     - TomTomSDKRoutePlanner (= 0.22.1)
+  - TomTomSDKRouteProjectionEngineCommon (0.22.1):
+    - TomTomSDKBindingRouteProjectionInternal (= 0.22.1)
+    - TomTomSDKCommon (= 0.22.1)
+    - TomTomSDKNavigationEngines (= 0.22.1)
+    - TomTomSDKRoute (= 0.22.1)
+  - TomTomSDKRouteProjectionEngineOffline (0.22.1):
+    - TomTomSDKBindingNDSStoreAccessInternal (= 0.22.1)
+    - TomTomSDKBindingRouteProjectionInternal (= 0.22.1)
+    - TomTomSDKCommon (= 0.22.1)
+    - TomTomSDKDataManagement (= 0.22.1)
+    - TomTomSDKDataManagementOffline (= 0.22.1)
+    - TomTomSDKNavigationEngines (= 0.22.1)
+    - TomTomSDKRoute (= 0.22.1)
+    - TomTomSDKRouteProjectionEngineCommon (= 0.22.1)
+  - TomTomSDKRouteProjectionEngineTileStore (0.22.1):
+    - TomTomSDKBindingNavigationTileStoreAccessInternal (= 0.22.1)
+    - TomTomSDKBindingRouteProjectionInternal (= 0.22.1)
+    - TomTomSDKCommon (= 0.22.1)
+    - TomTomSDKNavigationEngines (= 0.22.1)
+    - TomTomSDKNavigationTileStore (= 0.22.1)
+    - TomTomSDKRoute (= 0.22.1)
+    - TomTomSDKRouteProjectionEngineCommon (= 0.22.1)
   - TomTomSDKRouteReplanner (0.22.1):
     - TomTomSDKCommon (= 0.22.1)
     - TomTomSDKLocationProvider (= 0.22.1)
@@ -101,6 +265,14 @@ PODS:
     - TomTomSDKRoute (= 0.22.1)
     - TomTomSDKRoutePlanner (= 0.22.1)
     - TomTomSDKRouteReplanner (= 0.22.1)
+  - TomTomSDKSafetyCameras (0.22.1):
+    - TomTomSDKCommon (= 0.22.1)
+    - TomTomSDKMQTT (= 0.22.1)
+  - TomTomSDKSafetyLocationsDataAdapterOnline (0.22.1):
+    - TomTomSDKCommon (= 0.22.1)
+    - TomTomSDKMQTT (= 0.22.1)
+    - TomTomSDKNavigationHorizonDataAdapter (= 0.22.1)
+    - TomTomSDKSafetyCameras (= 0.22.1)
   - TomTomSDKTextToSpeech (0.22.1):
     - TomTomSDKTextToSpeechEngine (= 0.22.1)
   - TomTomSDKTextToSpeechEngine (0.22.1)
@@ -115,6 +287,8 @@ DEPENDENCIES:
   - TomTomSDKMapDisplay (= 0.22.1)
   - TomTomSDKNavigation (= 0.22.1)
   - TomTomSDKNavigationEngines (= 0.22.1)
+  - TomTomSDKNavigationOffline (= 0.22.1)
+  - TomTomSDKNavigationOnline (= 0.22.1)
   - TomTomSDKNavigationUI (= 0.22.1)
   - TomTomSDKRoute (= 0.22.1)
   - TomTomSDKRoutePlanner (= 0.22.1)
@@ -123,37 +297,39 @@ DEPENDENCIES:
 
 SPEC REPOS:
   https://repositories.tomtom.com/artifactory/api/pods/cocoapods:
-    - TomTomSDKBindingFrameworkClientCommonInternal
-    - TomTomSDKBindingFrameworkHTTPInternal
-    - TomTomSDKBindingFrameworkLoggingInternal
-    - TomTomSDKBindingFrameworkMemChannelInternal
-    - TomTomSDKBindingFrameworkSecurityInternal
-    - TomTomSDKBindingMapDisplayEngineInternal
-    - TomTomSDKBindingNavigationClientInternal
-    - TomTomSDKBindingNavigationDrivingAssistanceClientInternal
-    - TomTomSDKBindingNavigationMapMatcherPredictionInternal
-    - TomTomSDKBindingNavigationPositioningInternal
-    - TomTomSDKBindingNavigationServiceInternal
-    - TomTomSDKBindingNavigationTextGenerationInternal
-    - TomTomSDKCommon
-    - TomTomSDKCommonUI
-    - TomTomSDKDefaultTextToSpeech
-    - TomTomSDKFeatureToggle
-    - TomTomSDKLocationProvider
-    - TomTomSDKMapDisplay
-    - TomTomSDKNavigation
-    - TomTomSDKNavigationEngines
-    - TomTomSDKNavigationUI
-    - TomTomSDKNetworking
-    - TomTomSDKRoute
-    - TomTomSDKRoutePlanner
-    - TomTomSDKRoutePlannerOnline
-    - TomTomSDKRouteReplanner
-    - TomTomSDKRouteReplannerDefault
-    - TomTomSDKRouteReplannerInternal
-    - TomTomSDKTextToSpeech
-    - TomTomSDKTextToSpeechEngine
-    - TomTomSDKVehicle
+    - TomTomSDKBindingLocationContextProviderInternal
+    - TomTomSDKBindingMapMatchingInternal
+    - TomTomSDKBindingNavigationTileStoreAccessInternal
+    - TomTomSDKBindingNavigationTilingInternal
+    - TomTomSDKBindingNDSSQLiteInternal
+    - TomTomSDKBindingNDSStoreAccessInternal
+    - TomTomSDKBindingOnboardMapUpdateInternal
+    - TomTomSDKBindingOnboardOpenLRInternal
+    - TomTomSDKBindingRouteProjectionInternal
+    - TomTomSDKBindingVehicleHorizonInternal
+    - TomTomSDKBindingVehicleHorizonNDSMapInternal
+    - TomTomSDKDataManagement
+    - TomTomSDKDataManagementOffline
+    - TomTomSDKDataStoreMaintenanceEngine
+    - TomTomSDKHazards
+    - TomTomSDKHazardsDataAdapterOnline
+    - TomTomSDKHorizonEngineCommon
+    - TomTomSDKHorizonEngineOffline
+    - TomTomSDKLocationContextProviderEngineOffline
+    - TomTomSDKLocationContextProviderEngineTileStore
+    - TomTomSDKMapMatchingEngineCommon
+    - TomTomSDKMapMatchingEngineOffline
+    - TomTomSDKMapMatchingEngineTileStore
+    - TomTomSDKMQTT
+    - TomTomSDKNavigationHorizonDataAdapter
+    - TomTomSDKNavigationOffline
+    - TomTomSDKNavigationOnline
+    - TomTomSDKNavigationTileStore
+    - TomTomSDKRouteProjectionEngineCommon
+    - TomTomSDKRouteProjectionEngineOffline
+    - TomTomSDKRouteProjectionEngineTileStore
+    - TomTomSDKSafetyCameras
+    - TomTomSDKSafetyLocationsDataAdapterOnline
 
 SPEC CHECKSUMS:
   TomTomSDKBindingFrameworkClientCommonInternal: 311b6b0f9d7a089392c90d4638bcafffa133ebf3
@@ -161,33 +337,66 @@ SPEC CHECKSUMS:
   TomTomSDKBindingFrameworkLoggingInternal: 643418871c8098a0207142415afea31ed8787bd9
   TomTomSDKBindingFrameworkMemChannelInternal: 1f09f73056b7cf808783c2c50dc9daa3829e6827
   TomTomSDKBindingFrameworkSecurityInternal: c89eae2b37e07dde27d114951982e6357a74b0fc
+  TomTomSDKBindingLocationContextProviderInternal: 530ae9ef764614051486cc27eba014ca6b367f10
   TomTomSDKBindingMapDisplayEngineInternal: 50b655d9a41b45ca9ec08bd022927ad3cc00892b
+  TomTomSDKBindingMapMatchingInternal: c6d0418b21fa745fa735224d0db2dc9e4441b7ad
   TomTomSDKBindingNavigationClientInternal: b4dab5be23101879ab612fcc8de843967a6d8c5e
   TomTomSDKBindingNavigationDrivingAssistanceClientInternal: f7eb1a1e68fc8a7a18e8d991f332d4c208d32685
   TomTomSDKBindingNavigationMapMatcherPredictionInternal: 199649c3dc1387d78918f33b9d86b075752da5df
   TomTomSDKBindingNavigationPositioningInternal: afae007fc41c71c259a9fbc8f233a5171f4250a3
   TomTomSDKBindingNavigationServiceInternal: dbedb9adc38b4992a315d5548cc9132059296ccb
   TomTomSDKBindingNavigationTextGenerationInternal: 9ba9121b555f672c555c868e3a1b4f4b854d7bc1
+  TomTomSDKBindingNavigationTileStoreAccessInternal: 45fc1eff7619552c0777d436b6d9f9dfd6f0e14a
+  TomTomSDKBindingNavigationTilingInternal: c135c04d9b3d8e1cd53afb10c5ee10b987484b99
+  TomTomSDKBindingNDSSQLiteInternal: ce2977df1ad1914cda7c54ae6ffe4ab223933427
+  TomTomSDKBindingNDSStoreAccessInternal: 3f3aa3b73a4cf29114fde1852d00099782b72325
+  TomTomSDKBindingOnboardMapUpdateInternal: f113e053bcf66e59a79e07fe2a41b75589550798
+  TomTomSDKBindingOnboardOpenLRInternal: 4bb2f83f48a66ae799ec9010280f73cf7005f3c9
+  TomTomSDKBindingRouteProjectionInternal: cffbc1c3f46d9af4c7e7f9131c0ac925b536718c
+  TomTomSDKBindingVehicleHorizonInternal: 3c9fac824450ee89495ec885d161f5b721aabbad
+  TomTomSDKBindingVehicleHorizonNDSMapInternal: 0b76dc0849310d34b8a85d14f2464c091a56cede
   TomTomSDKCommon: 5437111af00002b07ee861f58f34be0d39a6c34a
   TomTomSDKCommonUI: 0e311c48585a4dea465be8c26968b67893d3059a
+  TomTomSDKDataManagement: 4d8bcbf1375347aa6622ffb98dabbe5870fdb23f
+  TomTomSDKDataManagementOffline: 1c2c94efae7d24a60204b96a19a76328eb93fe64
+  TomTomSDKDataStoreMaintenanceEngine: 730228e4f3f5379e3eb7ae449da42a2a2fe34489
   TomTomSDKDefaultTextToSpeech: 46a4769da769b861b7253efedd4a51493ffc4448
   TomTomSDKFeatureToggle: 02c189d4fad5af6360d846c4db762940a943eb91
+  TomTomSDKHazards: 11327d0848c66c7592fa927a1a33396a73296b08
+  TomTomSDKHazardsDataAdapterOnline: 54a91377f596d2d6dc15daabc4bbb2f711354f7a
+  TomTomSDKHorizonEngineCommon: 2b19c1df999cd72eb97f24ab94433326cc627985
+  TomTomSDKHorizonEngineOffline: 9d018cf70aa591d2ad423eff52ef22a807c331ec
+  TomTomSDKLocationContextProviderEngineOffline: 21fbc66dd9969d0f34b842230332027381401c7d
+  TomTomSDKLocationContextProviderEngineTileStore: 1f90c8d873417bac7cc3b2365b464bc2a2423431
   TomTomSDKLocationProvider: eb157849834b120283e5ce066ace18ba79b40484
   TomTomSDKMapDisplay: 1a9199644d19f7fa19821df44abdbb1b4b939a05
+  TomTomSDKMapMatchingEngineCommon: dcb3284a742318058978cbe2adab3734a8b0b3fb
+  TomTomSDKMapMatchingEngineOffline: df793b5d5430bd6f7657da7cecafbaee925dedde
+  TomTomSDKMapMatchingEngineTileStore: 4ed98b01ba025acd71e30ba9bcc1dab69a2b1adc
+  TomTomSDKMQTT: 5a14eaa3768bed5859c4b90f630309af0016bf5d
   TomTomSDKNavigation: 0a7865b9ae31efd3b7e39b5aa099b4c700fbefbe
   TomTomSDKNavigationEngines: 04144bc3329038aa3ac5c0c5b9917d31e97358a2
+  TomTomSDKNavigationHorizonDataAdapter: f47f22ab909cb1fae40e95ca3cee23b31c4cf017
+  TomTomSDKNavigationOffline: 5bf89316b23e8286c88452b3e1d41b9c6e51480a
+  TomTomSDKNavigationOnline: a422ca91fc9e130cc8cd78151d462c03ccd1ef9e
+  TomTomSDKNavigationTileStore: f8359528c8e79b587171bc869666c06082d931a4
   TomTomSDKNavigationUI: 585eddc19f8c1f21f42dc7b5b83a1bf7de72da2b
   TomTomSDKNetworking: 2007089746f3664ff0a94a829182c880f6ce379e
   TomTomSDKRoute: a25f337f7f136c724a4744c9526262d6f15e7f72
   TomTomSDKRoutePlanner: 04f40d850eb2522e7a0125a3023720781483a04c
   TomTomSDKRoutePlannerOnline: ab9b4407e49fc0236fa35eebd9c2ec91aecb00ac
+  TomTomSDKRouteProjectionEngineCommon: ca67c793dedaf2e638b1e390c1f31a737b43d46c
+  TomTomSDKRouteProjectionEngineOffline: 83d5c412772db8a1fa1e00566cfd13015032aab1
+  TomTomSDKRouteProjectionEngineTileStore: d66e562de6782e0c933a60f8f6683f6bbbf3ce6e
   TomTomSDKRouteReplanner: 7890e7c2dd8fd8c42b5f21020ee59f4efd2ee0b3
   TomTomSDKRouteReplannerDefault: 7fcf66357db4878dc1bc2e1110b5d7231a34038e
   TomTomSDKRouteReplannerInternal: 42152a04b0e2b01d8e4d0e1baec240e96091e54d
+  TomTomSDKSafetyCameras: fc8dc4153a5c2e2561939bd9427c88ec188eda1b
+  TomTomSDKSafetyLocationsDataAdapterOnline: 4dc338502e3eed4e6573384a8b9324145445226c
   TomTomSDKTextToSpeech: d09d718bdaa07b8c75b33356d1f9dce1d161368e
   TomTomSDKTextToSpeechEngine: 4a615926471c322b2dbebf8c21c9bbea99e67fc8
   TomTomSDKVehicle: c0c7def717681c41bd24341974ec75bd5dc454da
 
-PODFILE CHECKSUM: 7e0f03d8ace61dd36b6cfb3384ac7b785e09da91
+PODFILE CHECKSUM: 98542d367d4107507920c6a4d5274ac167b41a79
 
 COCOAPODS: 1.11.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -23,34 +23,13 @@ PODS:
   - TomTomSDKBindingNavigationTileStoreAccessInternal (0.22.1):
     - TomTomSDKBindingFrameworkLoggingInternal (= 0.22.1)
   - TomTomSDKBindingNavigationTilingInternal (0.22.1)
-  - TomTomSDKBindingNDSSQLiteInternal (0.22.1)
-  - TomTomSDKBindingNDSStoreAccessInternal (0.22.1):
-    - TomTomSDKBindingNDSSQLiteInternal (= 0.22.1)
-  - TomTomSDKBindingOnboardMapUpdateInternal (0.22.1):
-    - TomTomSDKBindingNDSSQLiteInternal (= 0.22.1)
-    - TomTomSDKBindingNDSStoreAccessInternal (= 0.22.1)
-  - TomTomSDKBindingOnboardOpenLRInternal (0.22.1):
-    - TomTomSDKBindingFrameworkLoggingInternal (= 0.22.1)
-    - TomTomSDKBindingNDSSQLiteInternal (= 0.22.1)
-    - TomTomSDKBindingNDSStoreAccessInternal (= 0.22.1)
   - TomTomSDKBindingRouteProjectionInternal (0.22.1)
-  - TomTomSDKBindingVehicleHorizonInternal (0.22.1)
-  - TomTomSDKBindingVehicleHorizonNDSMapInternal (0.22.1):
-    - TomTomSDKBindingNDSSQLiteInternal (= 0.22.1)
-    - TomTomSDKBindingNDSStoreAccessInternal (= 0.22.1)
   - TomTomSDKCommon (0.22.1):
     - TomTomSDKBindingFrameworkLoggingInternal (= 0.22.1)
   - TomTomSDKCommonUI (0.22.1):
     - TomTomSDKCommon (= 0.22.1)
   - TomTomSDKDataManagement (0.22.1):
     - TomTomSDKCommon (= 0.22.1)
-  - TomTomSDKDataManagementOffline (0.22.1):
-    - TomTomSDKBindingNavigationTilingInternal (= 0.22.1)
-    - TomTomSDKBindingNDSStoreAccessInternal (= 0.22.1)
-    - TomTomSDKBindingOnboardMapUpdateInternal (= 0.22.1)
-    - TomTomSDKCommon (= 0.22.1)
-    - TomTomSDKDataManagement (= 0.22.1)
-    - TomTomSDKNetworking (= 0.22.1)
   - TomTomSDKDataStoreMaintenanceEngine (0.22.1):
     - TomTomSDKDataManagement (= 0.22.1)
     - TomTomSDKNavigation (= 0.22.1)
@@ -60,45 +39,6 @@ PODS:
     - TomTomSDKTextToSpeechEngine (= 0.22.1)
   - TomTomSDKFeatureToggle (0.22.1):
     - TomTomSDKCommon (= 0.22.1)
-  - TomTomSDKHazards (0.22.1):
-    - TomTomSDKCommon (= 0.22.1)
-    - TomTomSDKMQTT (= 0.22.1)
-  - TomTomSDKHazardsDataAdapterOnline (0.22.1):
-    - TomTomSDKCommon (= 0.22.1)
-    - TomTomSDKHazards (= 0.22.1)
-    - TomTomSDKNavigationHorizonDataAdapter (= 0.22.1)
-  - TomTomSDKHorizonEngineCommon (0.22.1):
-    - TomTomSDKBindingVehicleHorizonInternal (= 0.22.1)
-    - TomTomSDKCommon (= 0.22.1)
-    - TomTomSDKHazardsDataAdapterOnline (= 0.22.1)
-    - TomTomSDKLocationProvider (= 0.22.1)
-    - TomTomSDKNavigation (= 0.22.1)
-    - TomTomSDKNavigationEngines (= 0.22.1)
-    - TomTomSDKNavigationHorizonDataAdapter (= 0.22.1)
-    - TomTomSDKRoute (= 0.22.1)
-    - TomTomSDKSafetyLocationsDataAdapterOnline (= 0.22.1)
-  - TomTomSDKHorizonEngineOffline (0.22.1):
-    - TomTomSDKBindingOnboardOpenLRInternal (= 0.22.1)
-    - TomTomSDKBindingVehicleHorizonInternal (= 0.22.1)
-    - TomTomSDKBindingVehicleHorizonNDSMapInternal (= 0.22.1)
-    - TomTomSDKCommon (= 0.22.1)
-    - TomTomSDKDataManagement (= 0.22.1)
-    - TomTomSDKDataManagementOffline (= 0.22.1)
-    - TomTomSDKHorizonEngineCommon (= 0.22.1)
-    - TomTomSDKLocationProvider (= 0.22.1)
-    - TomTomSDKNavigation (= 0.22.1)
-    - TomTomSDKNavigationEngines (= 0.22.1)
-    - TomTomSDKNavigationHorizonDataAdapter (= 0.22.1)
-    - TomTomSDKRoute (= 0.22.1)
-  - TomTomSDKLocationContextProviderEngineOffline (0.22.1):
-    - TomTomSDKBindingLocationContextProviderInternal (= 0.22.1)
-    - TomTomSDKBindingNDSStoreAccessInternal (= 0.22.1)
-    - TomTomSDKCommon (= 0.22.1)
-    - TomTomSDKDataManagement (= 0.22.1)
-    - TomTomSDKDataManagementOffline (= 0.22.1)
-    - TomTomSDKLocationProvider (= 0.22.1)
-    - TomTomSDKNavigationEngines (= 0.22.1)
-    - TomTomSDKRoutePlanner (= 0.22.1)
   - TomTomSDKLocationContextProviderEngineTileStore (0.22.1):
     - TomTomSDKBindingLocationContextProviderInternal (= 0.22.1)
     - TomTomSDKBindingNavigationTileStoreAccessInternal (= 0.22.1)
@@ -120,16 +60,6 @@ PODS:
     - TomTomSDKLocationProvider (= 0.22.1)
     - TomTomSDKNavigationEngines (= 0.22.1)
     - TomTomSDKRoute (= 0.22.1)
-  - TomTomSDKMapMatchingEngineOffline (0.22.1):
-    - TomTomSDKBindingMapMatchingInternal (= 0.22.1)
-    - TomTomSDKBindingNDSStoreAccessInternal (= 0.22.1)
-    - TomTomSDKCommon (= 0.22.1)
-    - TomTomSDKDataManagement (= 0.22.1)
-    - TomTomSDKDataManagementOffline (= 0.22.1)
-    - TomTomSDKLocationProvider (= 0.22.1)
-    - TomTomSDKMapMatchingEngineCommon (= 0.22.1)
-    - TomTomSDKNavigationEngines (= 0.22.1)
-    - TomTomSDKRoute (= 0.22.1)
   - TomTomSDKMapMatchingEngineTileStore (0.22.1):
     - TomTomSDKBindingMapMatchingInternal (= 0.22.1)
     - TomTomSDKBindingNavigationTileStoreAccessInternal (= 0.22.1)
@@ -140,8 +70,6 @@ PODS:
     - TomTomSDKNavigationEngines (= 0.22.1)
     - TomTomSDKNavigationTileStore (= 0.22.1)
     - TomTomSDKRoute (= 0.22.1)
-  - TomTomSDKMQTT (0.22.1):
-    - TomTomSDKCommon (= 0.22.1)
   - TomTomSDKNavigation (0.22.1):
     - TomTomSDKBindingFrameworkClientCommonInternal (= 0.22.1)
     - TomTomSDKBindingFrameworkHTTPInternal (= 0.22.1)
@@ -167,21 +95,6 @@ PODS:
     - TomTomSDKRoute (= 0.22.1)
     - TomTomSDKRoutePlanner (= 0.22.1)
     - TomTomSDKRouteReplanner (= 0.22.1)
-  - TomTomSDKNavigationHorizonDataAdapter (0.22.1):
-    - TomTomSDKCommon (= 0.22.1)
-    - TomTomSDKNavigationEngines (= 0.22.1)
-  - TomTomSDKNavigationOffline (0.22.1):
-    - TomTomSDKDataManagementOffline (= 0.22.1)
-    - TomTomSDKDataStoreMaintenanceEngine (= 0.22.1)
-    - TomTomSDKHorizonEngineOffline (= 0.22.1)
-    - TomTomSDKLocationContextProviderEngineOffline (= 0.22.1)
-    - TomTomSDKLocationProvider (= 0.22.1)
-    - TomTomSDKMapMatchingEngineOffline (= 0.22.1)
-    - TomTomSDKNavigation (= 0.22.1)
-    - TomTomSDKNavigationEngines (= 0.22.1)
-    - TomTomSDKRouteProjectionEngineOffline (= 0.22.1)
-    - TomTomSDKRouteReplanner (= 0.22.1)
-    - TomTomSDKVehicle (= 0.22.1)
   - TomTomSDKNavigationOnline (0.22.1):
     - TomTomSDKDataStoreMaintenanceEngine (= 0.22.1)
     - TomTomSDKLocationContextProviderEngineTileStore (= 0.22.1)
@@ -232,15 +145,6 @@ PODS:
     - TomTomSDKCommon (= 0.22.1)
     - TomTomSDKNavigationEngines (= 0.22.1)
     - TomTomSDKRoute (= 0.22.1)
-  - TomTomSDKRouteProjectionEngineOffline (0.22.1):
-    - TomTomSDKBindingNDSStoreAccessInternal (= 0.22.1)
-    - TomTomSDKBindingRouteProjectionInternal (= 0.22.1)
-    - TomTomSDKCommon (= 0.22.1)
-    - TomTomSDKDataManagement (= 0.22.1)
-    - TomTomSDKDataManagementOffline (= 0.22.1)
-    - TomTomSDKNavigationEngines (= 0.22.1)
-    - TomTomSDKRoute (= 0.22.1)
-    - TomTomSDKRouteProjectionEngineCommon (= 0.22.1)
   - TomTomSDKRouteProjectionEngineTileStore (0.22.1):
     - TomTomSDKBindingNavigationTileStoreAccessInternal (= 0.22.1)
     - TomTomSDKBindingRouteProjectionInternal (= 0.22.1)
@@ -265,14 +169,6 @@ PODS:
     - TomTomSDKRoute (= 0.22.1)
     - TomTomSDKRoutePlanner (= 0.22.1)
     - TomTomSDKRouteReplanner (= 0.22.1)
-  - TomTomSDKSafetyCameras (0.22.1):
-    - TomTomSDKCommon (= 0.22.1)
-    - TomTomSDKMQTT (= 0.22.1)
-  - TomTomSDKSafetyLocationsDataAdapterOnline (0.22.1):
-    - TomTomSDKCommon (= 0.22.1)
-    - TomTomSDKMQTT (= 0.22.1)
-    - TomTomSDKNavigationHorizonDataAdapter (= 0.22.1)
-    - TomTomSDKSafetyCameras (= 0.22.1)
   - TomTomSDKTextToSpeech (0.22.1):
     - TomTomSDKTextToSpeechEngine (= 0.22.1)
   - TomTomSDKTextToSpeechEngine (0.22.1)
@@ -287,7 +183,6 @@ DEPENDENCIES:
   - TomTomSDKMapDisplay (= 0.22.1)
   - TomTomSDKNavigation (= 0.22.1)
   - TomTomSDKNavigationEngines (= 0.22.1)
-  - TomTomSDKNavigationOffline (= 0.22.1)
   - TomTomSDKNavigationOnline (= 0.22.1)
   - TomTomSDKNavigationUI (= 0.22.1)
   - TomTomSDKRoute (= 0.22.1)
@@ -297,39 +192,12 @@ DEPENDENCIES:
 
 SPEC REPOS:
   https://repositories.tomtom.com/artifactory/api/pods/cocoapods:
-    - TomTomSDKBindingLocationContextProviderInternal
-    - TomTomSDKBindingMapMatchingInternal
     - TomTomSDKBindingNavigationTileStoreAccessInternal
-    - TomTomSDKBindingNavigationTilingInternal
-    - TomTomSDKBindingNDSSQLiteInternal
-    - TomTomSDKBindingNDSStoreAccessInternal
-    - TomTomSDKBindingOnboardMapUpdateInternal
-    - TomTomSDKBindingOnboardOpenLRInternal
-    - TomTomSDKBindingRouteProjectionInternal
-    - TomTomSDKBindingVehicleHorizonInternal
-    - TomTomSDKBindingVehicleHorizonNDSMapInternal
-    - TomTomSDKDataManagement
-    - TomTomSDKDataManagementOffline
-    - TomTomSDKDataStoreMaintenanceEngine
-    - TomTomSDKHazards
-    - TomTomSDKHazardsDataAdapterOnline
-    - TomTomSDKHorizonEngineCommon
-    - TomTomSDKHorizonEngineOffline
-    - TomTomSDKLocationContextProviderEngineOffline
     - TomTomSDKLocationContextProviderEngineTileStore
-    - TomTomSDKMapMatchingEngineCommon
-    - TomTomSDKMapMatchingEngineOffline
     - TomTomSDKMapMatchingEngineTileStore
-    - TomTomSDKMQTT
-    - TomTomSDKNavigationHorizonDataAdapter
-    - TomTomSDKNavigationOffline
     - TomTomSDKNavigationOnline
     - TomTomSDKNavigationTileStore
-    - TomTomSDKRouteProjectionEngineCommon
-    - TomTomSDKRouteProjectionEngineOffline
     - TomTomSDKRouteProjectionEngineTileStore
-    - TomTomSDKSafetyCameras
-    - TomTomSDKSafetyLocationsDataAdapterOnline
 
 SPEC CHECKSUMS:
   TomTomSDKBindingFrameworkClientCommonInternal: 311b6b0f9d7a089392c90d4638bcafffa133ebf3
@@ -348,36 +216,20 @@ SPEC CHECKSUMS:
   TomTomSDKBindingNavigationTextGenerationInternal: 9ba9121b555f672c555c868e3a1b4f4b854d7bc1
   TomTomSDKBindingNavigationTileStoreAccessInternal: 45fc1eff7619552c0777d436b6d9f9dfd6f0e14a
   TomTomSDKBindingNavigationTilingInternal: c135c04d9b3d8e1cd53afb10c5ee10b987484b99
-  TomTomSDKBindingNDSSQLiteInternal: ce2977df1ad1914cda7c54ae6ffe4ab223933427
-  TomTomSDKBindingNDSStoreAccessInternal: 3f3aa3b73a4cf29114fde1852d00099782b72325
-  TomTomSDKBindingOnboardMapUpdateInternal: f113e053bcf66e59a79e07fe2a41b75589550798
-  TomTomSDKBindingOnboardOpenLRInternal: 4bb2f83f48a66ae799ec9010280f73cf7005f3c9
   TomTomSDKBindingRouteProjectionInternal: cffbc1c3f46d9af4c7e7f9131c0ac925b536718c
-  TomTomSDKBindingVehicleHorizonInternal: 3c9fac824450ee89495ec885d161f5b721aabbad
-  TomTomSDKBindingVehicleHorizonNDSMapInternal: 0b76dc0849310d34b8a85d14f2464c091a56cede
   TomTomSDKCommon: 5437111af00002b07ee861f58f34be0d39a6c34a
   TomTomSDKCommonUI: 0e311c48585a4dea465be8c26968b67893d3059a
   TomTomSDKDataManagement: 4d8bcbf1375347aa6622ffb98dabbe5870fdb23f
-  TomTomSDKDataManagementOffline: 1c2c94efae7d24a60204b96a19a76328eb93fe64
   TomTomSDKDataStoreMaintenanceEngine: 730228e4f3f5379e3eb7ae449da42a2a2fe34489
   TomTomSDKDefaultTextToSpeech: 46a4769da769b861b7253efedd4a51493ffc4448
   TomTomSDKFeatureToggle: 02c189d4fad5af6360d846c4db762940a943eb91
-  TomTomSDKHazards: 11327d0848c66c7592fa927a1a33396a73296b08
-  TomTomSDKHazardsDataAdapterOnline: 54a91377f596d2d6dc15daabc4bbb2f711354f7a
-  TomTomSDKHorizonEngineCommon: 2b19c1df999cd72eb97f24ab94433326cc627985
-  TomTomSDKHorizonEngineOffline: 9d018cf70aa591d2ad423eff52ef22a807c331ec
-  TomTomSDKLocationContextProviderEngineOffline: 21fbc66dd9969d0f34b842230332027381401c7d
   TomTomSDKLocationContextProviderEngineTileStore: 1f90c8d873417bac7cc3b2365b464bc2a2423431
   TomTomSDKLocationProvider: eb157849834b120283e5ce066ace18ba79b40484
   TomTomSDKMapDisplay: 1a9199644d19f7fa19821df44abdbb1b4b939a05
   TomTomSDKMapMatchingEngineCommon: dcb3284a742318058978cbe2adab3734a8b0b3fb
-  TomTomSDKMapMatchingEngineOffline: df793b5d5430bd6f7657da7cecafbaee925dedde
   TomTomSDKMapMatchingEngineTileStore: 4ed98b01ba025acd71e30ba9bcc1dab69a2b1adc
-  TomTomSDKMQTT: 5a14eaa3768bed5859c4b90f630309af0016bf5d
   TomTomSDKNavigation: 0a7865b9ae31efd3b7e39b5aa099b4c700fbefbe
   TomTomSDKNavigationEngines: 04144bc3329038aa3ac5c0c5b9917d31e97358a2
-  TomTomSDKNavigationHorizonDataAdapter: f47f22ab909cb1fae40e95ca3cee23b31c4cf017
-  TomTomSDKNavigationOffline: 5bf89316b23e8286c88452b3e1d41b9c6e51480a
   TomTomSDKNavigationOnline: a422ca91fc9e130cc8cd78151d462c03ccd1ef9e
   TomTomSDKNavigationTileStore: f8359528c8e79b587171bc869666c06082d931a4
   TomTomSDKNavigationUI: 585eddc19f8c1f21f42dc7b5b83a1bf7de72da2b
@@ -386,17 +238,14 @@ SPEC CHECKSUMS:
   TomTomSDKRoutePlanner: 04f40d850eb2522e7a0125a3023720781483a04c
   TomTomSDKRoutePlannerOnline: ab9b4407e49fc0236fa35eebd9c2ec91aecb00ac
   TomTomSDKRouteProjectionEngineCommon: ca67c793dedaf2e638b1e390c1f31a737b43d46c
-  TomTomSDKRouteProjectionEngineOffline: 83d5c412772db8a1fa1e00566cfd13015032aab1
   TomTomSDKRouteProjectionEngineTileStore: d66e562de6782e0c933a60f8f6683f6bbbf3ce6e
   TomTomSDKRouteReplanner: 7890e7c2dd8fd8c42b5f21020ee59f4efd2ee0b3
   TomTomSDKRouteReplannerDefault: 7fcf66357db4878dc1bc2e1110b5d7231a34038e
   TomTomSDKRouteReplannerInternal: 42152a04b0e2b01d8e4d0e1baec240e96091e54d
-  TomTomSDKSafetyCameras: fc8dc4153a5c2e2561939bd9427c88ec188eda1b
-  TomTomSDKSafetyLocationsDataAdapterOnline: 4dc338502e3eed4e6573384a8b9324145445226c
   TomTomSDKTextToSpeech: d09d718bdaa07b8c75b33356d1f9dce1d161368e
   TomTomSDKTextToSpeechEngine: 4a615926471c322b2dbebf8c21c9bbea99e67fc8
   TomTomSDKVehicle: c0c7def717681c41bd24341974ec75bd5dc454da
 
-PODFILE CHECKSUM: 98542d367d4107507920c6a4d5274ac167b41a79
+PODFILE CHECKSUM: 1556ed98776178aa2ca925a039d975e67b354410
 
 COCOAPODS: 1.11.3

--- a/TomTomSDKExamples/Examples/UseCase/OnlineNavigationContent.swift
+++ b/TomTomSDKExamples/Examples/UseCase/OnlineNavigationContent.swift
@@ -21,6 +21,8 @@ import TomTomSDKLocationProvider
 import TomTomSDKMapDisplay
 import TomTomSDKNavigation
 import TomTomSDKNavigationEngines
+import TomTomSDKNavigationOffline
+import TomTomSDKNavigationOnline
 import TomTomSDKNavigationUI
 import TomTomSDKRoute
 import TomTomSDKRoutePlanner
@@ -51,13 +53,14 @@ final class NavigationController: ObservableObject {
         let routeReplanner = RouteReplannerFactory.create(routePlanner: routePlanner, replanningPolicy: .findBetter)
         let locationProvider = DefaultCLLocationProvider()
         let simulatedLocationProvider = SimulatedLocationProvider(delay: .tt.seconds(1))
-        let navigationConfiguration = NavigationConfiguration(
-            apiKey: Keys.apiKey,
-            locationProvider: simulatedLocationProvider,
-            routeReplanner: routeReplanner,
-            betterProposalAcceptanceMode: .automatic
-        )
-        let navigation = Navigation(configuration: navigationConfiguration)
+        let navigationConfiguration = OnlineTomTomNavigationFactory.Configuration(
+                    locationProvider: simulatedLocationProvider,
+                    routeReplanner: routeReplanner,
+                    apiKey: Keys.apiKey,
+                    betterProposalAcceptanceMode: .automatic
+                )
+         
+        let navigation = try! OnlineTomTomNavigationFactory.create(configuration: navigationConfiguration) as! Navigation
         let navigationModel = TomTomSDKNavigationUI.NavigationView.ViewModel(navigation, tts: textToSpeech)
 
         self.init(

--- a/TomTomSDKExamples/Examples/UseCase/OnlineNavigationContent.swift
+++ b/TomTomSDKExamples/Examples/UseCase/OnlineNavigationContent.swift
@@ -21,7 +21,6 @@ import TomTomSDKLocationProvider
 import TomTomSDKMapDisplay
 import TomTomSDKNavigation
 import TomTomSDKNavigationEngines
-import TomTomSDKNavigationOffline
 import TomTomSDKNavigationOnline
 import TomTomSDKNavigationUI
 import TomTomSDKRoute
@@ -54,13 +53,14 @@ final class NavigationController: ObservableObject {
         let locationProvider = DefaultCLLocationProvider()
         let simulatedLocationProvider = SimulatedLocationProvider(delay: .tt.seconds(1))
         let navigationConfiguration = OnlineTomTomNavigationFactory.Configuration(
-                    locationProvider: simulatedLocationProvider,
-                    routeReplanner: routeReplanner,
-                    apiKey: Keys.apiKey,
-                    betterProposalAcceptanceMode: .automatic
-                )
-         
-        let navigation = try! OnlineTomTomNavigationFactory.create(configuration: navigationConfiguration) as! Navigation
+            locationProvider: simulatedLocationProvider,
+            routeReplanner: routeReplanner,
+            apiKey: Keys.apiKey,
+            betterProposalAcceptanceMode: .automatic
+        )        
+        guard let navigation = try? OnlineTomTomNavigationFactory.create(configuration: navigationConfiguration) as? Navigation else {
+            fatalError("The navigation object could not be created!")
+        }
         let navigationModel = TomTomSDKNavigationUI.NavigationView.ViewModel(navigation, tts: textToSpeech)
 
         self.init(


### PR DESCRIPTION
This PR introduces the usage of the new online navigation factory methods to configure and create the navigation component. This is performed by importing the `TomTomSDKNavigationOnline` cocoapod and replacing the existing `Navigation` configuration and initialization methods with `OnlineTomTomNavigationFactory.Configuration()` and `OnlineTomTomNavigationFactory.create()`, respectively.