### PR TITLE
fix: empty remaining time on the eta view 

### DIFF
--- a/TomTomSDKExamples/Examples/UseCase/OnlineNavigationContent.swift
+++ b/TomTomSDKExamples/Examples/UseCase/OnlineNavigationContent.swift
@@ -446,7 +446,8 @@ extension NavigationController {
             language: locale,
             roadShieldReferences: .all,
             announcementPoints: .all,
-            phoneticsType: .IPA
+            phoneticsType: .IPA,
+            progressPoints: .all
         )
 
         let options = try RoutePlanningOptions(


### PR DESCRIPTION
What
---
"0 mins" is shown on the ETA view

Steps to reproduce:

1. Start navigation by long pressing any location on the map

![0-mins-remaining-time](https://github.com/tomtom-international/tomtom-navigation-ios-examples/assets/119294569/b518505f-3e5b-455e-8f13-6999719f7f4a)

How
---
- Set `.all` for the `progressPoints` in the `GuidanceOptions`
<img width="200" alt="Screenshot 2023-08-07 at 08 59 21" src="https://github.com/tomtom-international/tomtom-navigation-ios-examples/assets/119294569/9840ca10-9eac-47af-8427-5687f9f42a13">