### PR TITLE
ci: use new construct for testing against matched regex manager

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,7 +11,7 @@
   "separateMajorMinor": false,
   "packageRules": [
     {
-      "matchManagers": ["regex"],
+      "matchManagers": ["custom.regex"],
       "matchPaths": ["Podfile"],
       "groupName": "iOS cocoapods deps",
       "postUpgradeTasks" : {


### PR DESCRIPTION
After https://github.com/renovatebot/renovate/pull/24112 the way of testing against a matched regex manger changed. 
This fix contains the adaptation needed.