### PR TITLE
ci(renovate): use regex manager for matching

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,7 +11,7 @@
   "separateMajorMinor": false,
   "packageRules": [
     {
-      "matchManagers": ["custom.regex"],
+      "matchManagers": ["regex"],
       "matchPaths": ["Podfile"],
       "groupName": "iOS cocoapods deps",
       "postUpgradeTasks" : {


### PR DESCRIPTION
Renovate removed the newly added custom.regex way
of matching managers in package rules.
This adapts to the deprecation of the above feature

Renovate reverted back to the old definition: https://github.com/renovatebot/renovate/commit/30359ac0c3d22e54626ca4d6a48ded3772a2d317