### PR TITLE
ci(renovate): let username and author mail be autodetected

### DIFF
--- a/.github/renovate-config.js
+++ b/.github/renovate-config.js
@@ -1,8 +1,6 @@
 // Copyright (C) 2023 TomTom NV. All rights reserved.
 
 module.exports = {
-  gitAuthor: 'Renovate Bot <renovatebot@github.com>',
-  username: 'TomTomSdkIntegration[bot]',
   onboarding: false,
   platform: 'github',
   repositories: [


### PR DESCRIPTION
See: https://github.com/renovatebot/renovate/pull/24231 which makes the username and author autodetected when running with GitHub App.